### PR TITLE
Appli remember-me cookie domain on cancelCookie also

### DIFF
--- a/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
+++ b/web/src/main/java/org/springframework/security/web/authentication/rememberme/AbstractRememberMeServices.java
@@ -363,6 +363,9 @@ public abstract class AbstractRememberMeServices implements RememberMeServices,
 		logger.debug("Cancelling cookie");
 		Cookie cookie = new Cookie(cookieName, null);
 		cookie.setMaxAge(0);
+		if (cookieDomain != null) {
+			cookie.setDomain(cookieDomain);
+		}
 		cookie.setPath(getCookiePath(request));
 
 		response.addCookie(cookie);


### PR DESCRIPTION
### Summary

<!-- 
Please provide a high level summary of the issue you are having
-->

Following https://jira.spring.io/browse/SEC-3210, we now have the ability to specify the remember-me cookie domain, in order to have the same cookie on en.sample.org and fr.sample.org by example. But If you apply a domain in AbstractRememberMeServices.setCookie(), you should also apply it to cancelCookie().

In order to delete a cookie, one must specify the same domain.
### Actual Behavior

<!-- 
Please describe step by step the behavior you are observing
-->
1. Specify a domain http.rememberMe().rememberMeCookieDomain(".sample.org");
2. Login with remember me
3. Logout
   You are still logged, since the remember-me cookie was not deleted.
### Expected Behavior

<!--
Please describe step by step the behavior you expect
-->

After 3., you should be disconnected.
### Version

Spring Security 4.1.0.

<!--
Please describe what version you are using. Does the problem occur in other versions?
-->
### Suggested Correction

```
protected void cancelCookie(HttpServletRequest request, HttpServletResponse response) {
    logger.debug("Cancelling cookie");
    Cookie cookie = new Cookie(cookieName, null);
    cookie.setMaxAge(0);
    if (cookieDomain != null) {
        cookie.setDomain(cookieDomain);
    }
    cookie.setPath(getCookiePath(request));

    response.addCookie(cookie);
}
```

<!-- Please also confirm that you have signed the CLA by put an [X] in the box below: -->
- [] I have signed the CLA
